### PR TITLE
fix: cmux起動時のghostty-integration parse error解消

### DIFF
--- a/dot_zshenv
+++ b/dot_zshenv
@@ -46,12 +46,12 @@ sudo_path=(
 /opt/local/sbin(N-/)
 )
 
+# rootの場合はsudo用のパスもPATHに加える。
+# 一般ユーザー向けのsudoエイリアスはzsh/alias.zsh側で定義する
+# （.zshenvに置くとcmuxなど一部の環境でghostty-integrationの
+# sudo()関数定義とエイリアスが衝突しparse errorになるため）。
 if [ $(id -u) -eq 0 ]; then
-	# rootの場合はsudo用のパスもPATHに加える。
 	path=($sudo_path $path)
-else
-	# 一般ユーザーの場合はsudo時にsudo用のパスをPATHに加える。
-	alias sudo="sudo env PATH=\"$SUDO_PATH:$PATH\""
 fi
 
 # lessの設定
@@ -60,3 +60,6 @@ export LESS="-R"
 
 # エディタの設定
 export EDITOR=vim
+
+# rustup
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"

--- a/zsh/alias.zsh
+++ b/zsh/alias.zsh
@@ -18,7 +18,8 @@ alias vi=vim
 
 # sudo時にsudo_pathをPATHに加える（.zshenvではなくここで定義することで
 # cmuxなど一部の環境でghostty-integrationのsudo()関数定義と衝突するのを避ける）
-if [ $(id -u) -ne 0 ]; then
+if [ "$(id -u)" -ne 0 ]; then
+	# shellcheck disable=SC2139  # SUDO_PATH/PATHを定義時に展開して埋め込むのは意図通り
 	alias sudo="sudo env PATH=\"$SUDO_PATH:$PATH\""
 fi
 

--- a/zsh/alias.zsh
+++ b/zsh/alias.zsh
@@ -16,6 +16,12 @@ alias ......='cd ../../../../..'
 alias .......='cd ../../../../../..'
 alias vi=vim
 
+# sudo時にsudo_pathをPATHに加える（.zshenvではなくここで定義することで
+# cmuxなど一部の環境でghostty-integrationのsudo()関数定義と衝突するのを避ける）
+if [ $(id -u) -ne 0 ]; then
+	alias sudo="sudo env PATH=\"$SUDO_PATH:$PATH\""
+fi
+
 #====================================================================
 # Setting Extension Alias
 # Usage:


### PR DESCRIPTION
## Summary

- cmuxでターミナル起動時に下記のエラーが表示される問題を修正
  ```
  /Applications/cmux.app/Contents/Resources/ghostty/shell-integration/zsh/ghostty-integration:252: parse error near \`()'
  ```
- `sudo`エイリアスを`.zshenv`から`zsh/alias.zsh`(`.zshrc`経由)に移動
- 外部で追記されていた`. "\$HOME/.cargo/env"`もchezmoi管理下に統合

## 根本原因

cmuxのZDOTDIRブートストラップ(`/Applications/cmux.app/Contents/Resources/shell-integration/.zshenv:36`)が、ghostty-integrationを`autoload -Uz`ではなく`builtin source --`で直接読み込んでいる。

`autoload -U`はエイリアス展開を抑制するが、`source`では抑制されない。そのためロード順:

1. cmuxの`.zshenv`がユーザーの`~/.zshenv`をsource → `sudo`エイリアス定義
2. 続けてghostty-integrationをsource
3. パーサーが252行目の`sudo() {`を読む際にエイリアス展開が発生
4. `sudo env PATH=\"...\"() {` という不正な構文 → parse error

ghostty-integrationには別箇所(159行目付近)で`functions[_ghostty_preexec]`周りに`sudo`参照があり、ロード時に`defining function based on alias \`sudo'`という警告も出力されていた。

## 解決方針

zshベストプラクティスとして「エイリアスは`.zshrc`に置く」が推奨されている(`.zshenv`は非インタラクティブシェルでも読まれるため)。本リポジトリでは`zsh/alias.zsh`が`.zshrc`から読み込まれるため、そこに移設するのが筋。

cmux側に手を加える方法もあるが、アプリ更新で上書きされるためユーザー側で本質的に解決する形を採用。

## 変更内容

### `dot_zshenv`
- 非root時の`alias sudo`定義を削除
- `if [ \$(id -u) -eq 0 ]`のロジックはroot向けPATH追加のみに簡素化
- 経緯を説明するコメントを追加
- `. "\$HOME/.cargo/env"`を`[ -f ... ] && . ...`の安全形に変更してチェックイン

### `zsh/alias.zsh`
- 非root時の`sudo`エイリアス定義を追加(`SUDO_PATH`はexport済みなので`.zshrc`からも参照可能)

## Test plan

cmuxの実際のロード順序を再現するテスト(`/tmp/repro_cmux_parse_error.sh`)を作成し、修正前後で挙動を確認:

- [x] **Before(修正前)**: \`RESULT: parse error reproduced\` (252行目のparse error、159行目の警告ともに発生)
- [x] **After(修正後)**: \`RESULT: clean\` (parse error/警告ともに消失)
- [x] **sudo alias regression**: 通常のzsh起動後に \`alias sudo\` が \`sudo env PATH="..."\` として正しく定義されていることを確認
- [ ] 実機のcmuxで新規ターミナルを起動し、エラーが表示されないことを目視確認
- [ ] root権限のシェルでは\`path\`への\`sudo_path\`追加が引き続き機能することを目視確認

## 影響範囲

- 通常のzsh起動(Terminal.app/iTerm/Ghostty単体): 影響なし(これらはghostty-integrationを正しく\`autoload -Uz\`で読むため元から問題なし)
- cmux: parse error解消
- 非インタラクティブzsh(スクリプト等): \`alias sudo\`が定義されなくなるが、もともと\`.zshenv\`にエイリアスを置くのは非推奨でscript側はalias展開しないため実害なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)