### PR TITLE
refactor: gitconfigをtemplate化してchezmoi dataと統合

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,22 +41,24 @@ chezmoi apply -v
 
 ### PC固有設定
 
-chezmoi initの際に、ユーザー名とメールアドレスが対話的に設定されます。
-また、下記の名称のローカルファイルを作成することで、PC固有設定を追加できます。
+`chezmoi init` の際に対話的に入力するユーザー名・メールアドレスは
+chezmoi data に保存され、`~/.config/git/config` の `[user]` セクションに
+テンプレート展開で反映される。
 
-* ~/.gitconfig.local
-* ~/.vimrc.local
-* ~/.zshrc.local
+さらにPC固有の設定を追加したい場合、下記のローカルファイルを作成できる：
 
-gitのユーザ名、認証設定、プロキシ設定は~/.gitconfig.localに記述する。
+* `~/.gitconfig.local` — 認証情報・プロキシ等。git config の末尾で
+  `[include]` されるため、テンプレート側の設定も上書きできる
+* `~/.vimrc.local`
+* `~/.zshrc.local`
 
 ```.gitconfig.local
-[user]
-  name = Yuichi TSUNEMATSU
-  email = tunepolo@gmail.com
 [credential]
   helper = osxkeychain
 ```
+
+ユーザー名・メールアドレスを変更したい場合は `chezmoi edit-config` で
+chezmoi data を編集し、`chezmoi apply` を再実行する。
 
 ### Visual Studio Codeの設定
 

--- a/private_dot_config/git/config.tmpl
+++ b/private_dot_config/git/config.tmpl
@@ -1,5 +1,6 @@
-[include]
-	path = ~/.gitconfig.local
+[user]
+	name = {{ .name | quote }}
+	email = {{ .email | quote }}
 [color]
 	diff = auto
 	status = auto
@@ -90,3 +91,5 @@
 	insteadOf = https://github.com/
 [url "ssh://git@github.com/"]
     insteadOf = https://github.com/
+[include]
+	path = ~/.gitconfig.local


### PR DESCRIPTION
## Summary

- \`.chezmoi.toml.tmpl\` で取得していた \`email\` / \`name\` が活用されておらず、\`.gitconfig.local\` で \`[user]\` を手書きする運用になっていた
- \`private_dot_config/git/config\` を \`config.tmpl\` に変更し、chezmoi data から \`[user]\` を展開するように
- 既存の \`.gitconfig.local\` の運用を壊さないため、\`[include]\` を末尾に移動（ローカルファイルが必要なら上書き可能）

## 変更点

- \`private_dot_config/git/config\` → \`private_dot_config/git/config.tmpl\`
- \`[user]\` セクション追加（\`{{ .name | quote }}\` / \`{{ .email | quote }}\`）
- \`[include] path = ~/.gitconfig.local\` を先頭から末尾へ移動
- README から \`[user]\` 手書き手順を削除、\`chezmoi edit-config\` による変更方法を追記

## レンダリング結果

\`\`\`ini
[user]
	name = "Yuichi TSUNEMATSU"
	email = "tunepolo@gmail.com"
[color]
...
[url "ssh://git@github.com/"]
    insteadOf = https://github.com/
[include]
	path = ~/.gitconfig.local
\`\`\`

## Test plan

- [x] \`chezmoi data\` で \`email\` / \`name\` が正しく取得できることを確認
- [x] \`chezmoi execute-template < config.tmpl\` でレンダリング結果が期待通り
- [x] \`chezmoi --source=. diff\` で \`.config/git/config\` への変更が期待通り
- [ ] マージ後、\`chezmoi apply -v\` で \`~/.config/git/config\` が更新され、\`git config user.email\` が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)