### PR TITLE
chore: 設定ファイル群の小さなクリーンアップ

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,10 +1,8 @@
 # chezmoiで管理しないファイル（ツール、スクリプト、ドキュメント等）
-README.md
 Readme.md
 LICENSE
 .git/
 .github/
-.gitignore
 renovate.json5
 setup.sh
 shellcheck.sh

--- a/dot_zshenv
+++ b/dot_zshenv
@@ -17,6 +17,8 @@ typeset -U path
 #            -: シンボリックリンク先のパスを評価。
 #            /: ディレクトリのみ残す。
 path=(
+/opt/homebrew/bin(N-/)
+/opt/homebrew/sbin(N-/)
 /usr/local/bin(N-/)
 /opt/local/bin(N-/)
 /usr/bin(N-/)

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -31,7 +31,7 @@ killall "Finder" &> /dev/null
 defaults write com.apple.inputmethod.Kotoeri LiveConversionEnabled -bool false
 
 # 反映のため日本語IMを再起動
-killall -u $USER JapaneseIM
+killall -u "$USER" JapaneseIM
 
 # Dockを自動的に隠す
 defaults write com.apple.dock autohide -bool true

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,5 +1,5 @@
 {
-  extends: ["config:base"],
+  extends: ["config:recommended"],
   timezone: "Asia/Tokyo",
   labels: ["dependencies"],
   separateMinorPatch: true,

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 
-# nvmのインストール
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
-nvm install node
+set -euo pipefail
+
+# nvmのインストール（インストール済みならスキップ）
+if [ ! -d "${NVM_DIR:-$HOME/.nvm}" ]; then
+	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+	# shellcheck disable=SC1091
+	. "${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+	nvm install node
+fi
 
 ./npm_install.sh
 ./mac_install.sh
 
 # HomebrewでinstallしたGitのdiff-highlightを有効にする
 # https://udomomo.hatenablog.com/entry/2019/12/01/181404
-sudo ln -s /opt/homebrew/share/git-core/contrib/diff-highlight/diff-highlight /usr/local/bin/diff-highlight
+if [ ! -e /usr/local/bin/diff-highlight ]; then
+	sudo ln -s /opt/homebrew/share/git-core/contrib/diff-highlight/diff-highlight /usr/local/bin/diff-highlight
+fi

--- a/shellcheck.sh
+++ b/shellcheck.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
 shellcheck \
+	mac_install.sh \
 	npm_install.sh \
-    shellcheck.sh \
-    setup.sh
+	shellcheck.sh \
+	setup.sh


### PR DESCRIPTION
## Summary

最初の構成レビューで挙げた小ネタをまとめて一本のPRに：

| # | ファイル | 変更 |
|---|---|---|
| 3 | \`.chezmoiignore\` | 実体のない \`README.md\` と \`.gitignore\` エントリを削除（\`Readme.md\` のみ存在） |
| 5 | \`renovate.json5\` | deprecated な \`config:base\` を \`config:recommended\` に更新 |
| 6 | \`shellcheck.sh\` | チェック対象から漏れていた \`mac_install.sh\` を追加 |
| - | \`mac_install.sh\` | 上記追加で見つかった SC2086（\`$USER\` クオート漏れ）を修正 |
| 7 | \`setup.sh\` | nvm v0.38.0 (2021) → v0.40.3 (2024) に更新、\`set -euo pipefail\` 追加 |
| 8 | \`setup.sh\` | \`diff-highlight\` symlink を冪等化（2回目以降エラーにならない） |
| - | \`setup.sh\` | nvm のインストールも \`$NVM_DIR\` の存在チェックで冪等化 |
| 10 | \`dot_zshenv\` | Apple Silicon 向けに \`/opt/homebrew/{bin,sbin}\` を PATH 先頭に追加 |

## Test plan

- [x] \`./shellcheck.sh\` がすべて pass する（mac_install.sh含む）
- [x] \`zsh -n dot_zshenv\` で構文エラーなし
- [ ] マージ後、別マシンで \`./setup.sh\` を実行して冪等性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)