### PR TITLE
fix(sheldon): compinit順序とgibo補完の修正（実機検証で発覚）

### DIFF
--- a/dot_zsh/custom.zsh
+++ b/dot_zsh/custom.zsh
@@ -58,8 +58,7 @@ setopt transient_rprompt    #
 # 補完
 #====================================================================
 
-autoload -U compinit
-compinit
+# compinit は dot_zshrc で sheldon 読み込み前に実行済み
 zstyle ':completion:*:default' menu select=1
 
 # npm completion

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -1,6 +1,11 @@
 autoload -U promptinit
 promptinit
 
+# compinit を sheldon 読み込み前に走らせる
+# （zsh-better-npm-completion 等が source 中に compdef を呼ぶため）
+autoload -Uz compinit
+compinit
+
 # sheldon でプラグインを読み込み（設定は ~/.config/sheldon/plugins.toml）
 if command -v sheldon &>/dev/null; then
 	eval "$(sheldon source)"

--- a/private_dot_config/sheldon/plugins.toml
+++ b/private_dot_config/sheldon/plugins.toml
@@ -9,9 +9,9 @@ github = "chrissicool/zsh-256color"
 github = "rupa/z"
 use = ["z.sh"]
 
+# gibo は近年 Go 製にリライトされ、補完は `gibo completion zsh` で生成する形式に変更された
 [plugins.gibo-completion]
-github = "simonwhitaker/gibo"
-use = ["gibo-completion.zsh"]
+inline = 'if command -v gibo &>/dev/null; then eval "$(gibo completion zsh)"; fi'
 
 [plugins.zsh-completions]
 github = "zsh-users/zsh-completions"


### PR DESCRIPTION
## Summary

PR #31 (zplug → sheldon) を実機で起動した際に発見した2件のバグを修正。

## 修正内容

### 1. compinit 順序不正による \`compdef: command not found\` エラー

\`zsh-better-npm-completion\` 等のプラグインは source 中に \`compdef\` を呼ぶため、sheldon の eval より **前** に \`compinit\` を済ませる必要があった。

\`\`\`zsh
# Before (zshrc)
autoload -U promptinit
promptinit
eval "$(sheldon source)"   # ← compdef未定義でERROR

# After
autoload -U promptinit
promptinit
autoload -Uz compinit
compinit                   # ← 先にここで初期化
eval "$(sheldon source)"
\`\`\`

\`dot_zsh/custom.zsh\` 側の重複した \`compinit\` 呼び出しは削除。

### 2. gibo-completion の破綻

\`simonwhitaker/gibo\` は近年 Go 製にリライトされ、リポジトリ内の \`gibo-completion.zsh\` ファイルが **存在しなくなっていた**。zplug 時代も実は silent fail していたが、sheldon は明示的にエラーを出す。

修正: sheldon の \`inline\` directive で \`gibo completion zsh\` の出力を \`eval\`：

\`\`\`toml
[plugins.gibo-completion]
inline = 'if command -v gibo &>/dev/null; then eval "$(gibo completion zsh)"; fi'
\`\`\`

## 実機計測結果

\`time zsh -i -c exit\`:

| | Before | After |
|---|---|---|
| 起動時間 | **7.9秒** | **3.7秒** (-52%) |
| stderr エラー | 3件 | 0件 |

## Test plan

- [x] \`zsh -i -c exit\` がエラー無く完了
- [x] \`sheldon lock\` がすべてのプラグインで成功
- [x] \`time zsh -i -c exit\` で起動短縮を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)