### PR TITLE
chore: グローバルgitignoreに.claude/settings.local.jsonを追加

### DIFF
--- a/private_dot_config/git/ignore
+++ b/private_dot_config/git/ignore
@@ -2,3 +2,4 @@
 .nvmrc
 .vscode/*
 .DS_Store
+**/.claude/settings.local.json


### PR DESCRIPTION
## Summary

実機の \`~/.config/git/ignore\` に手動追加されていた \`**/.claude/settings.local.json\` を chezmoi 管理側に取り込んでドリフト解消。

Claude Code がリポジトリごとに生成する \`.claude/settings.local.json\` は個人ローカル設定のため、グローバル gitignore に登録しておくと誤コミット防止になる。

## Test plan

- [x] chezmoi diff で \`.config/git/ignore\` の差分が解消されることを確認
- [ ] マージ後、別マシンでも同じ ignore が適用される

🤖 Generated with [Claude Code](https://claude.com/claude-code)