### PR TITLE
feat: Bitwarden SSH Agentで鍵管理を集中化

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -95,6 +95,36 @@ chezmoi data を編集し、`chezmoi apply` を再実行する。
 登録する必要がある（GitHub 上で Verified バッジを付けるため）：
 [Telling Git about your signing key – GitHub Docs](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-ssh-key)
 
+### SSH 鍵を Bitwarden SSH Agent で管理する
+
+秘密鍵をディスクに置かず、Bitwarden Desktop の SSH Agent から提供する構成。
+新PCへの移行時は Bitwarden にログインするだけで鍵が即使えるようになる。
+
+`dot_zshenv` で `SSH_AUTH_SOCK` を Bitwarden のソケットに向けてあるので、
+Bitwarden Desktop で agent を有効にしている間は ssh / git が自動で
+Vault の鍵を使う（未起動ならシステム標準の agent にフォールバック）。
+
+#### 既存鍵を Bitwarden に取り込む手順
+
+1. Bitwarden Desktop を起動・ログイン
+2. **+ Add item → SSH Key** で新規アイテムを作成し、`~/.ssh/id_rsa`（秘密鍵）と
+   `~/.ssh/id_rsa.pub`（公開鍵）の中身を貼り付けて保存
+3. **Settings → SSH agent → Enable SSH agent** を ON
+4. シェルを開き直し、 `ssh-add -L` で公開鍵が表示されることを確認
+5. テスト: `ssh -T git@github.com`、`git commit --allow-empty -m 'signing test'`
+   で動作確認（コミット時に Bitwarden が承認ダイアログを出す）
+
+#### 新PCセットアップ時の鍵復元
+
+1. Bitwarden Desktop を入れてログイン → Settings → SSH agent を有効化
+2. `chezmoi init --apply` で dotfiles を反映（`SSH_AUTH_SOCK` が自動設定される）
+3. git 署名用に公開鍵をディスクに書き出し：
+   ```bash
+   mkdir -p ~/.ssh && chmod 700 ~/.ssh
+   ssh-add -L > ~/.ssh/id_rsa.pub
+   ```
+4. 動作確認: `ssh -T git@github.com`
+
 ### Visual Studio Codeの設定
 
 VSCode 組み込みの Settings Sync（GitHubアカウント連携）で同期する。

--- a/dot_zshenv
+++ b/dot_zshenv
@@ -63,5 +63,13 @@ export LESS="-R"
 # エディタの設定
 export EDITOR=nvim
 
+# Bitwarden SSH Agent（Bitwarden Desktop > Settings > SSH agent を有効にすると
+# このソケットが作成され、ssh / git push / 署名が Vault の秘密鍵を使うようになる。
+# Bitwarden が未起動 / 未有効ならソケットは存在せず、システム標準の agent に
+# フォールバックする。）
+if [ -S "$HOME/.bitwarden-ssh-agent.sock" ]; then
+	export SSH_AUTH_SOCK="$HOME/.bitwarden-ssh-agent.sock"
+fi
+
 # rustup
 [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"


### PR DESCRIPTION
## Summary

転職に伴う新PC移行に備え、SSH 鍵管理を Bitwarden Desktop の SSH Agent に集中化する。秘密鍵をディスクに置かず、Bitwarden にログインするだけで ssh / git push / コミット署名が動作する構成。

## 変更点

| ファイル | 内容 |
|---|---|
| \`dot_zshenv\` | \`~/.bitwarden-ssh-agent.sock\` が存在すれば \`SSH_AUTH_SOCK\` をそこに向ける（未起動時はシステム標準にフォールバック） |
| \`Readme.md\` | 既存鍵の取り込み手順と新PCでの復元手順を追記 |

## 設計判断

- **既存の \`~/.ssh/id_rsa\`（RSA）をそのまま流用** — GitHub の Signing Key 登録も済んでいるため鍵の世代交代は今回見送り
- **AWS 認証情報は管理外** — 現職固有のため転職タイミングで自然に切り離す
- **\`signingkey = ~/.ssh/id_rsa.pub\` は維持** — Bitwarden Agent でも公開鍵ファイルは必要（git が agent に「どの鍵で署名するか」を伝えるため）。新PCでは \`ssh-add -L > ~/.ssh/id_rsa.pub\` で復元可能

## マイグレーション手順（現PC上で先にやっておく）

1. Bitwarden Desktop で **+ Add item → SSH Key** を作成し、\`~/.ssh/id_rsa\` と \`id_rsa.pub\` を貼り付け
2. **Settings → SSH agent → Enable SSH agent** を ON
3. シェル再起動 → \`ssh-add -L\` で公開鍵が出ることを確認
4. \`ssh -T git@github.com\` と \`git commit --allow-empty -m test\` で動作確認

## Test plan

- [x] \`zsh -n dot_zshenv\` 構文OK
- [ ] マージ後 \`chezmoi apply\` で \`SSH_AUTH_SOCK\` 設定が反映される
- [ ] Bitwarden Agent 経由で \`ssh -T git@github.com\` が成功する
- [ ] git コミット署名が引き続き動作する（gpgsig 付与）
- [ ] Bitwarden 未起動時にも shell がエラー無く起動する

🤖 Generated with [Claude Code](https://claude.com/claude-code)