### PR TITLE
chore: デフォルトブランチ名をmasterからmainに切替

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,9 +2,9 @@ name: ShellCheck
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 jobs:
   shellcheck:

--- a/dot_local/bin/executable_git-update
+++ b/dot_local/bin/executable_git-update
@@ -4,15 +4,15 @@
 # https://sue445.hatenablog.com/entry/2019/03/02/220617
 
 if [ -n "$1" ]; then
-  master=$1
+  default_branch=$1
 else
-  master=`git remote show origin | grep 'HEAD branch:' | cut -d : -f 2 | tr -d '[[:space:]]'`
+  default_branch=`git symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's@^origin/@@'`
 fi
 
 current=`git branch --show-current`
 
-git checkout $master
-git pull origin $master --ff-only
+git checkout "$default_branch"
+git pull origin "$default_branch" --ff-only
 
-git checkout $current
-git rebase $master
+git checkout "$current"
+git rebase "$default_branch"

--- a/private_dot_config/git/config.tmpl
+++ b/private_dot_config/git/config.tmpl
@@ -15,6 +15,8 @@
 	preloadindex = true
 	fscache = true
 	hooksPath = githooks
+[init]
+	defaultBranch = main
 [push]
 	default = current
 [pull]
@@ -32,9 +34,9 @@
 	d = diff
 	dc = diff --cached
 	delete-merged-branches = !git branch --merged | grep -v \\* | xargs -I % git branch -d %
-	del-squashed-branch = "!f(){ base_branch=${1:-master} && echo ${base_branch} && git checkout -q ${base_branch} && git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base origin/${base_branch} $branch) && [[ $(git cherry origin/${base_branch} $(git commit-tree $(git rev-parse $branch^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done; git checkout -q -;};f"
+	del-squashed-branch = "!f(){ base_branch=${1:-main} && echo ${base_branch} && git checkout -q ${base_branch} && git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base origin/${base_branch} $branch) && [[ $(git cherry origin/${base_branch} $(git commit-tree $(git rev-parse $branch^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done; git checkout -q -;};f"
 	del-sq = !git del-squashed-branch `git def-branch`
-	def-branch = !git ls-remote --symref origin HEAD | head -n 1 | cut -f 1 | cut -d "/" -f 3-
+	def-branch = !git symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's@^origin/@@'
 	df = diff
 	diffr = diff --color-words --word-diff-regex='\\w+|[^[:space:]]'
 	dn = diff --name-only
@@ -57,8 +59,8 @@
 	s = status --short --branch
 	st = status
 	su = submodule update
-	sync = !git checkout master && git pull origin master && git fetch -p origin && git branch -d $(git branch --merged | grep -v master | grep -v '*')
-	openpr = "!f() { pr_number=$(git log --merges --oneline --reverse --ancestry-path $1...master | grep 'Merge pull request #' | head -n 1 | cut -f5 -d' ' | sed -e 's/#//'); gh pr view $pr_number --web; }; f"
+	sync = !git checkout main && git pull origin main && git fetch -p origin && git branch -d $(git branch --merged | grep -v main | grep -v '*')
+	openpr = "!f() { pr_number=$(git log --merges --oneline --reverse --ancestry-path $1...main | grep 'Merge pull request #' | head -n 1 | cut -f5 -d' ' | sed -e 's/#//'); gh pr view $pr_number --web; }; f"
 [merge]
 	tool = vimdiff
 	ff = false


### PR DESCRIPTION
## Summary

GitHub 上のリポジトリ default branch を **master → main** にリネームしたのに合わせ、設定ファイル内に残っていた \`master\` 参照を一掃する。

## 変更点

| ファイル | 内容 |
|---|---|
| \`private_dot_config/git/config.tmpl\` | \`[init] defaultBranch = main\` 追加、\`sync\`/\`openpr\`/\`del-squashed-branch\` aliasの master を main に、\`def-branch\` を local symref ベースに高速化 |
| \`.github/workflows/shellcheck.yml\` | \`branches: [master, main]\` → \`[main]\` |
| \`dot_local/bin/executable_git-update\` | 変数名 \`master\` → \`default_branch\`、HEAD branch 検出を \`symbolic-ref\` 利用に変更（local完結で高速）、変数を quote |

## def-branch alias の改善

旧版：
\`\`\`
def-branch = !git ls-remote --symref origin HEAD | head -n 1 | cut -f 1 | cut -d "/" -f 3-
\`\`\`
→ 毎回 GitHub にネットワーク問い合わせするため遅い

新版：
\`\`\`
def-branch = !git symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's@^origin/@@'
\`\`\`
→ ローカルの \`refs/remotes/origin/HEAD\` を読むだけ、ミリ秒で完了

## Test plan

- [x] \`./shellcheck.sh\` pass
- [x] \`shellcheck dot_local/bin/executable_git-update\` pass
- [x] \`chezmoi execute-template\` で template が正しくレンダリングされる
- [ ] マージ後 \`chezmoi apply\` で適用、\`git sync\` / \`git def-branch\` が動作

## 余談

\`ludeeus/action-shellcheck@master\` は third-party action のブランチ参照のため、今回の rename とは無関係。touch せず維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)