### PR TITLE
feat: mise のグローバル設定を chezmoi 管理に追加

### DIFF
--- a/private_dot_config/mise/config.toml
+++ b/private_dot_config/mise/config.toml
@@ -1,0 +1,4 @@
+[tools]
+node = "lts"
+python = "latest"
+ruby = "latest"


### PR DESCRIPTION
## Summary
- `~/.config/mise/config.toml` を `private_dot_config/mise/config.toml` として chezmoi 管理に取り込みました。
- node=lts / python=latest / ruby=latest のツール定義のみ。機密情報は含みません。
- 既存の `private_dot_config/` 配下と命名規則を揃えています（`~/.config/` が `0700` のため `private_` プレフィックス）。

## 検証
- `chezmoi --source=. diff` で差分なし
- `chezmoi --source=. managed` に `.config/mise/config.toml` が追加されたことを確認

## Test plan
- [ ] 別マシンで `chezmoi apply` 後、`~/.config/mise/config.toml` が配置されること
- [ ] `mise ls` で node/python/ruby が想定通りに認識されること