### PR TITLE
ci: macOS で chezmoi apply を検証するワークフローを追加

### DIFF
--- a/.github/workflows/macos-apply.yml
+++ b/.github/workflows/macos-apply.yml
@@ -40,13 +40,14 @@ jobs:
 
       - name: Verify run_once scripts recorded in chezmoi state
         run: |
-          chezmoi state dump --bucket=scriptState | tee state.log
+          chezmoi state get-bucket --bucket=scriptState | tee state.log
           missing=0
+          # state に記録される name は run_once_after_ プレフィックスを strip した形
           for s in \
-            run_once_after_01_macos-defaults.sh \
-            run_once_after_02_diff-highlight.sh \
-            run_once_after_03_npm-globals.sh; do
-            if ! grep -q "$s" state.log; then
+            01_macos-defaults.sh \
+            02_diff-highlight.sh \
+            03_npm-globals.sh; do
+            if ! grep -q "\.chezmoiscripts/$s" state.log; then
               echo "::error::$s not recorded in scriptState (script may not have executed)"
               missing=$((missing + 1))
             fi

--- a/.github/workflows/macos-apply.yml
+++ b/.github/workflows/macos-apply.yml
@@ -1,0 +1,64 @@
+name: chezmoi apply (macOS)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    name: chezmoi apply on macOS
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install chezmoi
+        run: brew install chezmoi
+
+      - name: Configure chezmoi data (non-interactive)
+        run: |
+          mkdir -p "$HOME/.config/chezmoi"
+          cat > "$HOME/.config/chezmoi/chezmoi.toml" <<'EOF'
+          [data]
+              email = "ci@example.com"
+              name = "CI Runner"
+          EOF
+
+      - name: chezmoi apply (first run — run_once_after scripts execute)
+        run: |
+          dest="$(mktemp -d)"
+          echo "CHEZMOI_DEST=$dest" >> "$GITHUB_ENV"
+          chezmoi apply \
+            --source="${GITHUB_WORKSPACE}" \
+            --destination="$dest" \
+            --verbose
+
+      - name: Verify run_once scripts recorded in chezmoi state
+        run: |
+          chezmoi state dump --bucket=scriptState | tee state.log
+          missing=0
+          for s in \
+            run_once_after_01_macos-defaults.sh \
+            run_once_after_02_diff-highlight.sh \
+            run_once_after_03_npm-globals.sh; do
+            if ! grep -q "$s" state.log; then
+              echo "::error::$s not recorded in scriptState (script may not have executed)"
+              missing=$((missing + 1))
+            fi
+          done
+          [ "$missing" -eq 0 ]
+
+      - name: Run chezmoiscripts behavior tests on macOS
+        run: bash tests/chezmoiscripts.test.sh
+
+      - name: chezmoi apply (second run — must succeed, scripts skipped via hash)
+        run: |
+          chezmoi apply \
+            --source="${GITHUB_WORKSPACE}" \
+            --destination="${CHEZMOI_DEST}" \
+            --verbose


### PR DESCRIPTION
## Summary

- GitHub Actions の `macos-latest` ランナーで本物の macOS 環境を使い `chezmoi apply` を走らせる workflow を追加
- `.chezmoiscripts/run_once_after_*` が macOS で完走するか、scriptState への記録が正しいか、二回目の apply で冪等に成功するかまでを CI で担保

## ワークフローの流れ

1. `brew install chezmoi`
2. `~/.config/chezmoi/chezmoi.toml` に `email` / `name` を書き込んで対話プロンプトを回避
3. **1回目の apply**: `--destination=$(mktemp -d)` で実 HOME を汚さず、`run_once_after_*` を実行
4. `chezmoi state dump --bucket=scriptState` で 3 スクリプトすべてが記録されていることを assert
5. `tests/chezmoiscripts.test.sh` を macOS 上でも実行（CI では従来 Linux でしか動いていなかった非 Darwin / npm 不在ケースのスタブテストを Darwin でも回す）
6. **2回目の apply**: hash 一致でスクリプトがスキップされ、冪等に成功することを確認

## スコープ外

- `brew bundle --global` は Mac App Store サインインが必要で CI 環境では落ちるため除外（README の通り手動運用）
- `tests/pre-commit-hook.test.sh` は `betterleaks` を必要とするため別ワークフロー（ShellCheck と同じ Linux ジョブに同居させる等）で扱うのが筋

## セキュリティ

- workflow で扱う入力は `${GITHUB_WORKSPACE}` のみで、`github.event.*` のような untrusted データを `run:` に展開していない
- `permissions: contents: read` で最小権限化

## Test plan

- [x] ローカルで `chezmoi apply --source=. --destination=<tmp> --dry-run -v` が成功することを確認
- [x] `./shellcheck.sh` 0 終了
- [x] `bash tests/chezmoiscripts.test.sh` 11 pass / 0 fail
- [ ] **この PR の Actions 上で macOS apply ワークフローが緑になること**（PR 作成後に自動実行され検証される）

🤖 Generated with [Claude Code](https://claude.com/claude-code)