### PR TITLE
ci: bash テストを Linux と macOS で常時実行する workflow を追加

### DIFF
--- a/.github/workflows/macos-apply.yml
+++ b/.github/workflows/macos-apply.yml
@@ -54,9 +54,6 @@ jobs:
           done
           [ "$missing" -eq 0 ]
 
-      - name: Run chezmoiscripts behavior tests on macOS
-        run: bash tests/chezmoiscripts.test.sh
-
       - name: chezmoi apply (second run — must succeed, scripts skipped via hash)
         run: |
           chezmoi apply \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  chezmoiscripts:
+    name: chezmoiscripts test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run chezmoiscripts behavior tests
+        run: bash tests/chezmoiscripts.test.sh
+
+  pre-commit-hook:
+    name: pre-commit hook test (macOS)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install betterleaks
+        run: brew install betterleaks
+
+      - name: Run pre-commit hook tests
+        run: bash tests/pre-commit-hook.test.sh


### PR DESCRIPTION
## Summary

- これまで `tests/` 配下のスクリプトは手動実行のみで CI のセーフティネットが無かった
- `tests.yml` を追加し、PR / main push で自動実行されるようにする
- macOS apply workflow から重複していたテストステップを削除

## ジョブ構成

| ジョブ | OS | 内容 |
|---|---|---|
| `chezmoiscripts test (ubuntu-latest)` | Linux | `tests/chezmoiscripts.test.sh` を実行（依存無し） |
| `chezmoiscripts test (macos-latest)` | macOS | 同上 |
| `pre-commit hook test (macOS)` | macOS | `brew install betterleaks` 後 `tests/pre-commit-hook.test.sh` を実行 |

`fail-fast: false` で片方が落ちてももう片方の結果が取れるようにしている。

## 設計判断

- **pre-commit hook test を macOS のみにした理由**: テスト本体が `betterleaks` を要求する。macOS runner は brew がプリインストール済みで `brew install betterleaks` が高速。Linux で同じことをやるには `Homebrew/actions/setup-homebrew` の追加と数分の install が必要で、片方の OS で回せれば十分なので避けた。
- **macos-apply.yml の `Run chezmoiscripts behavior tests on macOS` を削除**: tests.yml が macOS でも回すため重複。macos-apply.yml の責務は chezmoi apply 自体の検証に絞る。

## Test plan

- [x] `./shellcheck.sh` 0 終了
- [x] `bash tests/chezmoiscripts.test.sh` 11 pass / 0 fail
- [x] `bash tests/pre-commit-hook.test.sh` 2 pass / 0 fail
- [ ] **PR 作成後に tests workflow が緑になること**（Linux x1, macOS x2 ジョブ）
- [ ] macos-apply workflow が引き続き緑のこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)