### PR TITLE
fix(nvim): indent-blankline の indent.char を幅1の文字に変更

### DIFF
--- a/private_dot_config/nvim/lua/plugins.lua
+++ b/private_dot_config/nvim/lua/plugins.lua
@@ -39,7 +39,7 @@ return {
     "lukas-reineke/indent-blankline.nvim",
     main = "ibl",
     event = "BufReadPre",
-    opts = { indent = { char = "│" } },
+    opts = { indent = { char = "▏" } },
   },
 
   --================================================================


### PR DESCRIPTION
## 変更内容

indent-blankline.nvim 起動時に以下のエラーが発生していたため修正。

```
Failed to run `config` for indent-blankline.nvim
char: expected indent.char to have a display width of 0 or 1, got │
'│ ' has a display width of 2
```

## 原因

`│`（U+2502 BOX DRAWINGS LIGHT VERTICAL）は East Asian Ambiguous Width 文字であり、環境によって表示幅が2と判定される。

## 対応

`▏`（U+258F LEFT ONE EIGHTH BLOCK）に変更。この文字は表示幅が確実に1であり、見た目もインデントガイド線として同等。