### PR TITLE
fix(nvim): indent-blankline の indent.char を ASCII の | に変更

### DIFF
--- a/private_dot_config/nvim/lua/plugins.lua
+++ b/private_dot_config/nvim/lua/plugins.lua
@@ -39,7 +39,7 @@ return {
     "lukas-reineke/indent-blankline.nvim",
     main = "ibl",
     event = "BufReadPre",
-    opts = { indent = { char = "▏" } },
+    opts = { indent = { char = "|" } },
   },
 
   --================================================================


### PR DESCRIPTION
## 変更内容

#56 の修正（`│` → `▏`）後も同様のエラーが継続したため追加修正。

```
char: expected indent.char to have a display width of 0 or 1, got ▏
'▏ ' has a display width of 2
```

## 原因

`ambiwidth=double` の環境では `▏`（U+258F）も幅2と判定される。

## 対応

確実に幅1となる ASCII の `|` に変更する。