### PR TITLE
feat: Ghostty向けデスクトップ通知を有効化

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,4 +1,5 @@
 # chezmoiで管理しないファイル（ツール、スクリプト、ドキュメント等）
+.claude/settings.local.json
 Readme.md
 LICENSE
 .git/

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "preferredNotifChannel": "ghostty",
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.py"


### PR DESCRIPTION
## 変更内容

- `dot_claude/settings.json` に `preferredNotifChannel: "ghostty"` を追加
- `.chezmoiignore` に `.claude/settings.local.json` を追加（ローカル設定を chezmoi 管理対象外に）

## 背景

Claude Code の通知を Ghostty のデスクトップ通知として受け取れるよう設定した。これにより、長いタスクが完了したときなど Ghostty がバックグラウンドにある状態でも通知が届くようになる。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)