### PR TITLE
fix: GitHub SSH insteadOf ルールを削除

### DIFF
--- a/private_dot_config/git/config.tmpl
+++ b/private_dot_config/git/config.tmpl
@@ -83,10 +83,6 @@
 	root = ~/Repos
 [fetch]
 	prune = true
-[url "git@github.com:"]
-	insteadOf = https://github.com/
-[url "ssh://git@github.com/"]
-    insteadOf = https://github.com/
 [gpg]
 	format = ssh
 [commit]


### PR DESCRIPTION
## Summary

- `~/.config/git/config` から GitHub の `url.insteadOf` ルール（HTTPS → SSH 書き換え）を削除

## 背景

sheldon がプラグインを内部の libgit2 でクローン・フェッチする際、SSH insteadOf ルールにより SSH 認証が走り、zsh 起動時にハングする問題が発生していた。

## Test plan

- [ ] 新しいターミナルを開き、zsh が止まらずに起動することを確認
- [ ] `git clone https://github.com/...` が HTTPS で動作することを確認
- [ ] `~/Repos/mfpbadmin/` 配下のリポジトリ（SSH URL）の `git push` / `git pull` が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)