### PR TITLE
fix: 非インタラクティブシェルで mise シムを PATH に追加

### DIFF
--- a/dot_zshenv
+++ b/dot_zshenv
@@ -26,6 +26,10 @@ path=(
 /usr/X11R6/bin(N-/)
 $HOME/.local/bin(N-/)
 $HOME/bin(N-/)
+# mise シムを非インタラクティブシェル（スクリプト・エディタ統合等）でも有効にする。
+# .zshrc の `mise activate zsh` はインタラクティブシェル専用のため、
+# 非インタラクティブシェルでは PATH に乗らずツールが見つからない問題を回避。
+$HOME/.local/share/mise/shims(N-/)
 )
 
 # sudo時のパスの設定


### PR DESCRIPTION
## 問題

`.zshrc` の `mise activate zsh` はインタラクティブシェル起動時にのみ実行される。
そのため、スクリプトや Claude Code などのエディタ統合（非インタラクティブシェル）では mise 管理のツール（yarn、node 等）が PATH に乗らず、`command not found` になる。

## 原因

| ファイル | 読み込みタイミング |
|---|---|
| `.zshrc` | インタラクティブシェルのみ |
| `.zshenv` | すべてのシェル（非インタラクティブ含む） |

`mise activate zsh` が `.zshrc` にあるため、非インタラクティブシェルではシムが PATH に追加されない。

## 修正

`.zshenv` の `path` 配列に `$HOME/.local/share/mise/shims` を追加。  
既存の `(N-/)` glob 修飾子により、mise 未インストール環境では無視される。

## テスト

- [x] `zsh -c 'which yarn'` でシムが解決されることを確認
- [x] インタラクティブシェルで `mise activate zsh` が二重実行されても `typeset -U path` で重複排除される

🤖 Generated with [Claude Code](https://claude.com/claude-code)