### PR TITLE
fix(nvim): accelerated-jk の lazy-load 設定を修正し j/k キーが動かないバグを解消

### DIFF
--- a/private_dot_config/nvim/init.lua
+++ b/private_dot_config/nvim/init.lua
@@ -100,10 +100,6 @@ map("n", "<F2>", "<ESC>:bp<CR>")
 map("n", "<F3>", "<ESC>:bn<CR>")
 map("n", "<F4>", "<ESC>:bw<CR>")
 
--- 表示行単位の移動
-map("n", "j", "gj")
-map("n", "k", "gk")
-
 -- ESC×2 でハイライト消去
 map("n", "<ESC><ESC>", ":nohlsearch<CR><ESC>")
 

--- a/private_dot_config/nvim/lua/plugins.lua
+++ b/private_dot_config/nvim/lua/plugins.lua
@@ -97,11 +97,10 @@ return {
   --================================================================
   {
     "rhysd/accelerated-jk",
-    keys = { "j", "k" },
-    init = function()
-      vim.keymap.set("n", "j", "<Plug>(accelerated_jk_gj)")
-      vim.keymap.set("n", "k", "<Plug>(accelerated_jk_gk)")
-    end,
+    keys = {
+      { "j", "<Plug>(accelerated_jk_gj)", mode = "n" },
+      { "k", "<Plug>(accelerated_jk_gk)", mode = "n" },
+    },
   },
 
   --================================================================


### PR DESCRIPTION
## 概要

nvim で `j`/`k` キーによるカーソル移動が機能しない問題を修正。

## 原因

`accelerated-jk` プラグインの設定で `init` 関数内に `<Plug>` マッピングを書いていたため、プラグインがまだロードされていない状態で `j`/`k` が未定義の `<Plug>(accelerated_jk_gj/gk)` へ向けられ、キーを押しても何も起きない状態になっていた。

## 修正内容

- `plugins.lua`: `init` 関数を廃止し、`keys` テーブルにマッピングを直接定義。lazy.nvim はこの書き方でプラグインのロードと最終マッピング設定を正しく連動させる。
- `init.lua`: `j`→`gj` / `k`→`gk` のマッピングを削除。accelerated-jk が内部で `gj`/`gk` ベースの移動を処理するため不要かつ混乱のもとになっていた。

## テスト

- nvim 起動後に `j`/`k` でカーソル移動が正常に動作することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)