### PR TITLE
feat: snapzy の設定ファイルを chezmoi 管理下に追加

### DIFF
--- a/private_dot_config/snapzy/config.toml
+++ b/private_dot_config/snapzy/config.toml
@@ -1,0 +1,299 @@
+schema_version = 1
+snapzy_min_version = "1.29.1"
+
+[general]
+language = "ja"
+appearance = "system"
+play_sounds = true
+url_scheme_enabled = true
+show_menu_bar_icon = true
+start_at_login = false
+export_location = "~/Desktop/Snapzy"
+
+[updates]
+check_automatically = true
+download_automatically = false
+channel = "stable"
+
+[diagnostics]
+enabled = true
+retention_days = 3
+
+[capture]
+hide_desktop_icons = false
+hide_desktop_widgets = false
+
+[capture.naming]
+screenshot_template = "Snapzy_{datetime}_{ms}"
+recording_template = "Snapzy_Recording_{datetime}"
+
+[capture.screenshot]
+format = "png"
+include_snapzy = false
+show_cursor = false
+freeze_area = false
+show_selection_area_overlay = true
+reverse_magnifier_zoom_direction = false
+
+[capture.scrolling]
+show_hints = true
+
+[capture.ocr]
+success_notification = false
+
+[capture.object_cutout]
+auto_crop = true
+
+[capture.after.screenshot]
+save = true
+quick_access = true
+copy_file = true
+open_annotate = false
+upload_to_cloud = false
+
+[capture.after.recording]
+save = true
+quick_access = true
+copy_file = true
+open_annotate = false
+upload_to_cloud = false
+
+[recording]
+format = "mov"
+quality = "high"
+fps = 30
+output_mode = "video"
+capture_system_audio = true
+capture_microphone = false
+microphone_device_id = "system-default"
+remember_last_area = true
+include_snapzy = false
+show_cursor = true
+highlight_clicks = false
+show_keystrokes = false
+video_editor_zoom_transition_duration = 0.4
+
+[recording.mouse_highlight]
+size = 50.0
+animation_duration = 0.7
+color = "#003AFF"
+opacity = 0.5
+ripple_count = 3
+
+[recording.keystrokes]
+font_size = 16.0
+position = "bottomCenter"
+display_duration = 1.5
+
+[recording.annotation_shortcuts]
+modifier = "shift"
+hold_duration = 0.3
+
+[quick_access]
+enabled = true
+position = "bottomRight"
+auto_dismiss = true
+auto_dismiss_delay = 10.0
+pause_countdown_on_hover = true
+overlay_scale = 1.0
+drag_drop = true
+two_finger_swipe_to_dismiss = true
+swipe_sensitivity = 1.0
+trackpad_swipe_mode = "inverted"
+swipe_left_action = "dismiss"
+swipe_right_action = "dismiss"
+hide_card_when_window_open = true
+animation_style = "slide"
+actions_order = ["copy", "saveOrOpen", "dismiss", "delete", "edit", "uploadToCloud", "pinToScreen"]
+enabled_actions = ["copy", "delete", "dismiss", "edit", "pinToScreen", "saveOrOpen", "uploadToCloud"]
+
+[quick_access.slots]
+center_top = "copy"
+center_bottom = "saveOrOpen"
+top_trailing = "dismiss"
+top_leading = "delete"
+bottom_leading = "edit"
+bottom_trailing = "uploadToCloud"
+
+[history]
+enabled = true
+retention_days = 30
+max_count = 500
+background_style = "hud"
+open_on_launch = false
+
+[history.floating]
+enabled = true
+position = "topCenter"
+default_filter = "all"
+max_displayed_items = 10
+scale = 1.0
+auto_clear_days = 0
+
+[cloud]
+provider = "aws_s3"
+bucket = ""
+region = "us-east-1"
+endpoint = ""
+custom_domain = ""
+expire_time = "7d"
+uploads_window_position = "center"
+
+[annotate]
+clipboard_image_open_behavior = "ask"
+close_after_drag = true
+bring_forward_after_drag = false
+quick_properties_sync = true
+
+[shortcuts]
+enabled = true
+
+[shortcuts.global.fullscreen]
+enabled = true
+key = "3"
+modifiers = ["command", "shift"]
+
+[shortcuts.global.area]
+enabled = true
+key = "4"
+modifiers = ["command", "shift"]
+
+[shortcuts.global.area_annotate]
+enabled = true
+key = "7"
+modifiers = ["command", "shift"]
+
+[shortcuts.global.active_window]
+enabled = true
+key = "9"
+modifiers = ["command", "shift"]
+
+[shortcuts.global.scrolling_capture]
+enabled = true
+key = "6"
+modifiers = ["command", "shift"]
+
+[shortcuts.global.recording]
+enabled = true
+key = "5"
+modifiers = ["command", "shift"]
+
+[shortcuts.global.pause_resume_recording]
+enabled = true
+key = ""
+modifiers = []
+
+[shortcuts.global.toggle_pen_recording]
+enabled = true
+key = ""
+modifiers = []
+
+[shortcuts.global.restart_recording]
+enabled = true
+key = ""
+modifiers = []
+
+[shortcuts.global.delete_recording]
+enabled = true
+key = ""
+modifiers = []
+
+[shortcuts.global.annotate]
+enabled = true
+key = "A"
+modifiers = ["command", "shift"]
+
+[shortcuts.global.video_editor]
+enabled = true
+key = "E"
+modifiers = ["command", "shift"]
+
+[shortcuts.global.cloud_uploads]
+enabled = true
+key = "L"
+modifiers = ["command", "shift"]
+
+[shortcuts.global.shortcut_list]
+enabled = true
+key = "K"
+modifiers = ["command", "shift"]
+
+[shortcuts.global.ocr]
+enabled = true
+key = "2"
+modifiers = ["command", "shift"]
+
+[shortcuts.global.smart_element]
+enabled = true
+key = "4"
+modifiers = ["shift", "option"]
+
+[shortcuts.global.object_cutout]
+enabled = true
+key = "1"
+modifiers = ["command", "shift"]
+
+[shortcuts.global.history]
+enabled = true
+key = "H"
+modifiers = ["command", "shift"]
+
+[shortcuts.overlay.area_application_capture]
+enabled = true
+key = "A"
+modifiers = []
+
+[shortcuts.overlay.recording_application_capture]
+enabled = true
+key = "A"
+modifiers = []
+
+[shortcuts.quick_access.edit_latest_capture]
+enabled = false
+key = "↩"
+modifiers = ["command"]
+
+[shortcuts.annotate_tools]
+disabled = []
+crop = "c"
+selection = "v"
+rectangle = "r"
+filledRectangle = "f"
+oval = "o"
+arrow = "a"
+line = "l"
+text = "t"
+highlighter = "h"
+blur = "b"
+spotlight = "s"
+counter = "n"
+watermark = "w"
+pencil = "p"
+
+[shortcuts.annotate_actions]
+disabled = []
+
+[shortcuts.annotate_actions.copy_and_close]
+enabled = true
+key = "C"
+modifiers = ["command", "shift"]
+
+[shortcuts.annotate_actions.toggle_sidebar]
+enabled = true
+key = "B"
+modifiers = ["command"]
+
+[shortcuts.annotate_actions.toggle_pin]
+enabled = true
+key = "P"
+modifiers = ["command", "control"]
+
+[shortcuts.annotate_actions.cloud_upload]
+enabled = true
+key = "U"
+modifiers = ["command"]
+
+[shortcuts.annotate_actions.auto_redact_sensitive_data]
+enabled = true
+key = ""
+modifiers = []


### PR DESCRIPTION
## Summary

- snapzy（スクリーンショット・録画アプリ）の設定ファイル `~/.config/snapzy/config.toml` を chezmoi 管理下に追加
- `private_dot_config/snapzy/config.toml` として管理

## 設定内容

- 言語: 日本語
- キャプチャ設定（スクリーンショット・録画のフォーマット、保存先等）
- ショートカットキー設定
- クイックアクセス・履歴設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)