### PR TITLE
fix(mise): npm ツール移行で失われた rust / flutter を復元

### DIFF
--- a/private_dot_config/mise/config.toml
+++ b/private_dot_config/mise/config.toml
@@ -4,5 +4,7 @@ python = "latest"
 ruby = "latest"
 go = "latest"
 java = "temurin-25.0.3+9.0.LTS"
+rust = "latest"
+flutter = { version = "latest", checksum_expr = '"sha256:" + filter(fromJSON(body).releases, { #.archive endsWith filename })[0].sha256', platforms = { linux-x64 = { checksum_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json", url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_{{ version }}-stable.tar.xz" }, macos-arm64 = { checksum_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_macos.json", url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_arm64_{{ version }}-stable.zip" }, macos-x64 = { checksum_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_macos.json", url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_{{ version }}-stable.zip" }, windows-x64 = { checksum_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_windows.json", url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_{{ version }}-stable.zip" } }, version_expr = 'fromJSON(body).releases | filter({ #.channel == "stable" }) | map({ replace(#.version, "-stable", "") }) | sortVersions()', version_list_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json" }
 "npm:npm-check-updates" = "latest"
 "npm:git-delete-squashed" = "latest"


### PR DESCRIPTION
## Summary
- `1885689 feat(mise): npm グローバルパッケージ管理を mise tools に移行` で `rust` / `flutter` のツール宣言が誤って削除されていたため復元し、`npm:npm-check-updates` / `npm:git-delete-squashed` と共存させた。
- ローカル環境では、これまで mise 管理外だった旧来の `npm install -g npm-check-updates git-delete-squashed`（mise 管理の Node LTS 配下への直接インストールで、mise の npm: tools 版より PATH 優先順位が高く隠してしまっていた）を削除し、`mise install` 後に mise の npm: tools 経由のバイナリ（`ncu` v23.0.1 / `git-delete-squashed`）が正しく解決されることを確認した。

## Test plan
- [x] `mise install` で `npm:npm-check-updates` / `npm:git-delete-squashed` / `rust` / `flutter` が全てインストールされることを確認
- [x] `which ncu` / `which git-delete-squashed` / `which rustc` / `which flutter` が mise 管理下のパスを指すことを確認
- [x] `rustc --version` / `flutter --version` / `ncu --version` が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)