### PR TITLE
feat(claude): 権限プロンプト削減とセキュリティ強化のための設定を追加

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -11,7 +11,150 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "grep -q '\"dangerouslyDisableSandbox\"[[:space:]]*:[[:space:]]*true' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"サンドボックス外での実行には承認が必要です\"}}'; exit 0",
+            "timeout": 10,
+            "statusMessage": "sandbox-escape-gate"
+          }
+        ]
+      }
     ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:api.github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:*.githubusercontent.com)",
+      "WebFetch(domain:*.googleapis.com)",
+      "WebFetch(domain:accounts.google.com)",
+      "WebFetch(domain:*.slack.com)",
+      "WebFetch(domain:*.amazonaws.com)",
+      "WebFetch(domain:registry.npmjs.org)",
+      "WebFetch(domain:registry.terraform.io)",
+      "WebFetch(domain:docs.anthropic.com)",
+      "WebFetch(domain:code.claude.com)",
+      "WebSearch(*)"
+    ],
+    "ask": [
+      "Bash(terraform apply*)",
+      "Bash(terraform destroy*)",
+      "Bash(kubectl apply*)",
+      "Bash(kubectl delete*)",
+      "Bash(docker push*)",
+      "Bash(gh pr merge*)"
+    ],
+    "deny": [
+      "Read(**/.env)",
+      "Read(**/.envrc)",
+      "Read(**/.env.*)",
+      "Read(**/secrets/**)",
+      "Read(**/credentials)",
+      "Read(~/.aws/credentials)",
+      "Read(~/.aws/config)",
+      "Read(~/.ssh/id_*)",
+      "Read(~/.netrc)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(~/.config/gcloud/application_default_credentials.json)",
+      "Bash(sudo *)",
+      "Bash(su *)",
+      "Bash(git push --force *)",
+      "Bash(git push -f *)",
+      "Bash(git reset --hard *)",
+      "Bash(git clean -f *)"
+    ]
+  },
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "allowUnsandboxedCommands": true,
+    "excludedCommands": [
+      "git *",
+      "docker *",
+      "docker-compose *",
+      "gh *",
+      "chezmoi *",
+      "gcloud *",
+      "bq *",
+      "gsutil *",
+      "aws *",
+      "kubectl *",
+      "terraform *"
+    ],
+    "filesystem": {
+      "denyRead": [
+        "~/.aws/",
+        "~/.ssh/",
+        "~/.netrc",
+        "~/.config/gcloud/",
+        "~/.config/gh/",
+        "~/.kube/"
+      ],
+      "allowWrite": [
+        "~/.npm",
+        "~/.pnpm-store",
+        "~/go/pkg",
+        "~/Library/Caches/go-build",
+        "~/.gradle/caches",
+        "~/.gradle/wrapper",
+        "~/.m2/repository",
+        "~/.cargo/registry",
+        "~/.cargo/git",
+        "~/.cache"
+      ]
+    },
+    "network": {
+      "allowedDomains": [
+        "github.com",
+        "*.github.com",
+        "api.github.com",
+        "raw.githubusercontent.com",
+        "*.githubusercontent.com",
+        "registry.npmjs.org",
+        "*.npmjs.com",
+        "registry.yarnpkg.com",
+        "rubygems.org",
+        "*.rubygems.org",
+        "pypi.org",
+        "*.pypi.org",
+        "files.pythonhosted.org",
+        "proxy.golang.org",
+        "sum.golang.org",
+        "golang.org",
+        "crates.io",
+        "static.crates.io",
+        "index.crates.io",
+        "static.rust-lang.org",
+        "repo.maven.apache.org",
+        "repo1.maven.org",
+        "*.gradle.org",
+        "packagist.org",
+        "repo.packagist.org",
+        "*.googleapis.com",
+        "accounts.google.com",
+        "*.google.com",
+        "*.googleusercontent.com",
+        "*.slack.com",
+        "files.slack.com",
+        "*.amazonaws.com",
+        "registry.terraform.io",
+        "*.terraform.io",
+        "registry-1.docker.io",
+        "*.docker.io",
+        "api.anthropic.com",
+        "*.anthropic.com",
+        "claude.ai",
+        "*.claude.ai"
+      ]
+    }
   },
   "statusLine": {
     "type": "command",


### PR DESCRIPTION
## 概要

- Claude Code のグローバル設定 (`dot_claude/settings.json`) に、権限プロンプトを減らしつつ安全性を高めるための設定を追加
- 前職で使っていた設定ファイルを参考に、現環境に合わせて内容を検証・取り込み

## 変更内容

- `permissions.deny`: `.env`/`secrets`/`credentials`/SSH秘密鍵/`.pem`/`.key` 等の読み取り、`sudo`/`su`、`git push --force`/`git reset --hard`/`git clean -f` を恒久的にブロック
- `permissions.ask`: `terraform apply/destroy`、`kubectl apply/delete`、`docker push`、`gh pr merge` は個別確認を必須化
- `permissions.allow`: 汎用開発ドメイン(GitHub/Google/Slack/AWS/npm/Terraform Registry/Anthropic)への WebFetch と WebSearch を許可
- `sandbox`: macOSネイティブサンドボックスを有効化し、サンドボックス内のBashは自動許可（プロンプト削減の本体）。`git`/`docker`/`gh`/`gcloud`/`kubectl`/`terraform`/`chezmoi`等はサンドボックス対象外として従来の許可フローを維持
- `hooks.PreToolUse`: `dangerouslyDisableSandbox: true` でのBash実行前に承認を求めるゲートを追加

前職設定にあった組織ログイン強制系の項目（`forceLoginMethod`等）や、Salesforce/HubSpot/dbt向けの許可ドメインは、現環境に不要なため除外しています。

## テスト

- [x] `jq` で設定ファイルのJSON構文とキー構造を検証
- [x] `PreToolUse` フックをstdin JSONで手動テストし、`dangerouslyDisableSandbox: true` の有無で正しく分岐することを確認
- [x] サンドボックス有効化後、`chezmoi` コマンド自体がサンドボックスでブロックされる問題を発見し `excludedCommands` に `chezmoi *` を追加して解消
- [ ] 実運用でBashコマンドの確認プロンプトが実際に減っているか、`git`/`gh`等が従来通り動作するかを継続確認